### PR TITLE
Update NOTICE.txt to include additional open source software licenses

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -67,7 +67,7 @@ Licensed under BSD-3-Clause (https://github.com/pybind/pybind11/blob/master/LICE
 
 pyrealsense2 (https://pypi.org/project/pyrealsense2/)
 2017 Intel Corporation
-Licensed under Apach 2.0 (https://github.com/IntelRealSense/librealsense/blob/master/LICENSE)
+Licensed under Apache 2.0 (https://github.com/IntelRealSense/librealsense/blob/master/LICENSE)
 
 rti.connext (https://pypi.org/project/rti.connext/)
 2024 Real-Time Innovations, Inc. |br|


### PR DESCRIPTION
- Added new entries for build-essential, dearpygui, gcc, libstdcxx-ng, libxcb-cursor0, Orbit Surgical, pybind11-dev, pyrealsense2, rti.connext, toml, and x11-utils.
- Updated existing entries for boto3, coverage, parametrized, and torch with correct links and licensing information.
