### PR TITLE
Change i4h repo links to use release 0.1.0

### DIFF
--- a/tools/env_setup_robot_surgery.sh
+++ b/tools/env_setup_robot_surgery.sh
@@ -54,7 +54,7 @@ pushd $PROJECT_ROOT/third_party/IsaacLab
 # ---- Install IsaacSim and necessary dependencies ----
 echo "Installing IsaacSim..."
 pip install 'isaacsim[all,extscache]==4.5.0' \
-    git+ssh://git@github.com/isaac-for-healthcare/i4h-asset-catalog.git@main \
+    git+ssh://git@github.com/isaac-for-healthcare/i4h-asset-catalog.git@v0.1.0 \
     --extra-index-url https://pypi.nvidia.com
 
 

--- a/tools/env_setup_robot_us.sh
+++ b/tools/env_setup_robot_us.sh
@@ -54,7 +54,7 @@ fi
 echo "Installing IsaacSim..."
 pip install 'isaacsim[all,extscache]==4.5.0' \
     rti.connext==7.3.0 pyrealsense2==2.55.1.6486 toml==0.10.2 dearpygui==2.0.0 \
-    git+ssh://git@github.com/isaac-for-healthcare/i4h-asset-catalog.git@main \
+    git+ssh://git@github.com/isaac-for-healthcare/i4h-asset-catalog.git@v0.1.0 \
     setuptools==75.8.0 pydantic==2.10.6 \
     --extra-index-url https://pypi.nvidia.com
 

--- a/workflows/robotic_surgery/README.md
+++ b/workflows/robotic_surgery/README.md
@@ -42,7 +42,7 @@ bash tools/env_setup_robot_surgery.sh
 ### Download the I4H assets
 
 Use the following command will download the assets to the `~/.cache/i4h-assets/<sha256>` directory.
-Please refer to the [Asset Container Helper](https://github.com/isaac-for-healthcare/i4h-asset-catalog/blob/v0.1.0ea/docs/catalog_helper.md) for more details.
+Please refer to the [Asset Container Helper](https://github.com/isaac-for-healthcare/i4h-asset-catalog/blob/v0.1.0/docs/catalog_helper.md) for more details.
 
 ```sh
 i4h-asset-retrieve

--- a/workflows/robotic_ultrasound/README.md
+++ b/workflows/robotic_ultrasound/README.md
@@ -52,7 +52,7 @@ conda activate robotic_ultrasound
 
 #### Install the Raytracing Ultrasound Simulator
 To use the ultrasound-raytracing simulator, you can choose one of the following options:
-- (experimental) Download the pre-release version from [here](https://github.com/isaac-for-healthcare/i4h-sensor-simulation/releases/tag/v0.1.0ea) and extract the folder to `workflows/robotic_ultrasound/scripts/raysim`.
+- (experimental) Download the pre-release version from [here](https://github.com/isaac-for-healthcare/i4h-sensor-simulation/releases/tag/v0.1.0) and extract the folder to `workflows/robotic_ultrasound/scripts/raysim`.
 
 - (recommended) Install and build it by following the instructions in [Raytracing Ultrasound Simulator](https://github.com/isaac-for-healthcare/i4h-sensor-simulation/tree/main/ultrasound-raytracing#installation).
 
@@ -80,7 +80,7 @@ This is due to requirements of `isaaclab` and `openpi` used different fixed vers
 ### Download the I4H assets
 
 Use the following command will download the assets to the `~/.cache/i4h-assets/<sha256>` directory.
-Please refer to the [Asset Container Helper](https://github.com/isaac-for-healthcare/i4h-asset-catalog/blob/v0.1.0ea/docs/catalog_helper.md) for more details.
+Please refer to the [Asset Container Helper](https://github.com/isaac-for-healthcare/i4h-asset-catalog/blob/v0.1.0/docs/catalog_helper.md) for more details.
 
 ```sh
 i4h-asset-retrieve

--- a/workflows/robotic_ultrasound/scripts/simulation/README.md
+++ b/workflows/robotic_ultrasound/scripts/simulation/README.md
@@ -206,7 +206,7 @@ based on 3D meshes. The simulator uses Holoscan framework and DDS communication 
 
 #### NVIDIA OptiX Raytracing with Python Bindings
 
-For instructions on preparing and building the Python module, please refer to the [Environment Setup](../../README.md#install-the-raytracing-ultrasound-simulator) instructions and [Ultrasound Raytracing README](https://github.com/isaac-for-healthcare/i4h-sensor-simulation/blob/v0.1.0ea/ultrasound-raytracing/README.md) to setup the `raysim` module correctly.
+For instructions on preparing and building the Python module, please refer to the [Environment Setup](../../README.md#install-the-raytracing-ultrasound-simulator) instructions and [Ultrasound Raytracing README](https://github.com/isaac-for-healthcare/i4h-sensor-simulation/blob/v0.1.0/ultrasound-raytracing/README.md) to setup the `raysim` module correctly.
 
 
 #### Configuration


### PR DESCRIPTION
This PR updates repository links to use the release version 0.1.0 instead of the experimental tag v0.1.0ea.