### PR TITLE
removed double folder for raysim.

### DIFF
--- a/tools/env_setup/install_raysim.sh
+++ b/tools/env_setup/install_raysim.sh
@@ -35,7 +35,7 @@ wget https://github.com/isaac-for-healthcare/i4h-asset-catalog/releases/download
 
 echo "Unzipping Raysim..."
 
-unzip $PROJECT_ROOT/workflows/robotic_ultrasound/scripts/raysim.zip -d $PROJECT_ROOT/workflows/robotic_ultrasound/scripts/raysim
+unzip $PROJECT_ROOT/workflows/robotic_ultrasound/scripts/raysim.zip -d $PROJECT_ROOT/workflows/robotic_ultrasound/scripts
 
 rm $PROJECT_ROOT/workflows/robotic_ultrasound/scripts/raysim.zip
 


### PR DESCRIPTION
Fixes #ISSUE_NUMBER

### Description
removes the additional raysim folder from the unpacking command.
Previously, when installing raysim, the import of raysim failed due to the folder structure: 
scripts/raysim/raysim/...

